### PR TITLE
3 amelioration du build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,11 @@ else()
     message(STATUS "This project is a top-level one")
 endif()
 
-set(SRCS
-	src/main.cpp
-)
+include(build/sources.cmake)
 
 set(HEADERS
 )
 
-add_executable(bzs ${SRCS} ${HEADERS})
+add_executable(bzs ${SOURCES} ${HEADERS})
 
 target_link_libraries(bzs PUBLIC bad-zapple)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,6 @@ set(SRCS
 set(HEADERS
 )
 
-add_executable(bad_zapple_serv ${SRCS} ${HEADERS})
+add_executable(bzs ${SRCS} ${HEADERS})
 
-target_link_libraries(bad_zapple_serv PUBLIC bad_zapple)
+target_link_libraries(bzs PUBLIC bad-zapple)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ re: fclean all
 
 lsp:
 	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
+	make lsp -C libbad-zapple
 
 .PHONY: lsp 
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ NAME=bzs
 BUILD_DIR=build/
 TARGET=$(BUILD_DIR)$(NAME)
 
-all: $(TARGET)
+all: 
+	make -C $(BUILD_DIR)
 
 .PHONY: all 
 
@@ -11,14 +12,17 @@ run: $(TARGET)
 
 .PHONY: run 
 
-$(TARGET): cmake-rule
+$(TARGET): 
 	make -C $(BUILD_DIR)
 	
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-cmake-rule: update-sources
+update-cmake: update-sources
 	cmake -B $(BUILD_DIR)
+	make -C libbad-zapple update-cmake
+
+.PHONY: update-cmake 
 
 clean:
 	make clean -C $(BUILD_DIR)
@@ -39,12 +43,11 @@ re: fclean all
 
 lsp:
 	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
-	make lsp -C libbad-zapple
+	make -C libbad-zapple lsp
 
 .PHONY: lsp 
 
 update-sources: $(BUILD_DIR)
 	@sh ./tools/list_sources.sh build/sources.cmake
-	make update-sources -C libbad-zapple
 
 .PHONY: update-sources

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+NAME=bzs
+BUILD_DIR=build/
+TARGET=$(BUILD_DIR)$(NAME)
+
+all: $(TARGET)
+
+run: $(TARGET)
+	$(TARGET) $(ARGS)
+
+
+$(TARGET): cmake-rule
+	make -C $(BUILD_DIR)
+	
+
+%.o: %.cpp $(HEADER)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+cmake-rule:
+	mkdir -p $(BUILD_DIR)
+	cmake -B $(BUILD_DIR)
+
+clean:
+	make clean -C $(BUILD_DIR)
+
+re: clean all
+
+lsp:
+	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
+
+.PHONY: all run cmake-rule clean fclean re

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,46 @@ TARGET=$(BUILD_DIR)$(NAME)
 
 all: $(TARGET)
 
+.PHONY: all 
+
 run: $(TARGET)
 	$(TARGET) $(ARGS)
 
+.PHONY: run 
 
 $(TARGET): cmake-rule
 	make -C $(BUILD_DIR)
 	
-
-%.o: %.cpp $(HEADER)
-	$(CC) $(CFLAGS) -c $< -o $@
-
-cmake-rule:
+$(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
+
+cmake-rule: update-sources
 	cmake -B $(BUILD_DIR)
 
 clean:
 	make clean -C $(BUILD_DIR)
 
-re: clean all
+.PHONY: clean 
+
+fclean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: fclean 
+
+prune: fclean
+	make -C libbad-zapple fclean
+	
+re: fclean all
+
+.PHONY: re 
 
 lsp:
 	cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B $(BUILD_DIR)
 
-.PHONY: all run cmake-rule clean fclean re
+.PHONY: lsp 
+
+update-sources: $(BUILD_DIR)
+	@sh ./tools/list_sources.sh build/sources.cmake
+	make update-sources -C libbad-zapple
+
+.PHONY: update-sources

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ You will build a network-based multiplayer game.
 
 # zappy_42_server
 Server hosting a zappy instance (post CC 42 school project)
+
+# compilation
+
+```
+make update-cmake
+make
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
-#include "bad_zapple.h"
+#include "bad_zapple.hpp"
 
 int main(int ac, char **av) {
-	dummy(35);
+	test(ac, av);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 #include "bad_zapple.hpp"
 
 int main(int ac, char **av) {
-	test(ac, av);
+	return 0;
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
-#include "bad_zapple.hpp"
+#include <iostream>
 
 int main(int ac, char **av) {
+	std::cout << "zap zap zappy" << std::endl;
+	std::cout << "zaps" << std::endl;
 	return 0;
 }
 

--- a/tools/list_sources.sh
+++ b/tools/list_sources.sh
@@ -1,0 +1,7 @@
+echo listing sources in $1
+echo sources found:
+echo set\(SOURCES > $1
+find src/ -name *.cpp | sed 's/^/\t/' | tee -a $1
+find src/ -name *.hpp | sed 's/^/\t/' | tee -a $1
+find src/ -name *.h | sed 's/^/\t/' | tee -a $1
+echo \) >> $1


### PR DESCRIPTION
J'ai name l'executable bzs comme bad zapple server -> je n'ai pas check si il devait y avoir un nom en particulier

L'ensemble des fichiers mis dans le directory src sont maintenant liste dans le fichier sources.cmake dans le directory build avec la regle update-sources par le biais du script list_sources.sh dans le directory tools.

en plus des regles classique all clean fclean et re.

prune appel fclean dans la lib aussi.

lsp genere les fichier de clang pour mon lsp sur nvim.

J'en ai profite pour faire un .PHONY a chaque ligne. Tdameros m'en a parle je trouve ca plus clean.
